### PR TITLE
작성중 다이어리 생성 및 업데이트 기능 추가

### DIFF
--- a/src/main/java/com/konnect/diary/controller/DiaryController.java
+++ b/src/main/java/com/konnect/diary/controller/DiaryController.java
@@ -4,8 +4,16 @@ import com.konnect.auth.dto.CustomUserPrincipal;
 import com.konnect.diary.dto.CreateDiaryDraftRequestDTO;
 import com.konnect.diary.dto.CreateDiaryResponseDTO;
 import com.konnect.diary.service.DiaryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -21,16 +29,60 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
-    @PostMapping("/user/diaries/draft")
+    @Operation(
+            summary = "임시저장 다이어리 생성/수정",
+            description = "드래프트(draft) 상태인 다이어리를 생성하거나 업데이트합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "드래프트 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CreateDiaryResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "드래프트 생성 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CreateDiaryResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력값", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PostMapping(path = "/user/diaries/draft")
     @ResponseBody
-    public ResponseEntity<CreateDiaryResponseDTO> createDiaryDraft(
+    public ResponseEntity<CreateDiaryResponseDTO> saveDraft(
+            @Parameter(
+                    description = "드래프트 저장 요청 DTO",
+                    required = true,
+                    schema = @Schema(implementation = CreateDiaryDraftRequestDTO.class)
+            )
             @RequestPart("data") CreateDiaryDraftRequestDTO requestDTO,
+
+            @Parameter(
+                    description = "썸네일 이미지 파일 (optional)",
+                    in = ParameterIn.HEADER,
+                    content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+            )
             @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+
+            @Parameter(
+                    description = "본문 이미지 파일 목록, 최대 9장 (optional)",
+                    in = ParameterIn.HEADER,
+                    content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+            )
+            @RequestPart(value = "images", required = false) List<MultipartFile> imageFiles,
+
             @AuthenticationPrincipal CustomUserPrincipal userDetails
     ) {
         requestDTO.setUserId(userDetails.getId());
-        CreateDiaryResponseDTO response = diaryService.createDiaryDraft(requestDTO, thumbnail, images);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        CreateDiaryResponseDTO dto =
+                diaryService.createDiaryDraft(requestDTO, thumbnail, imageFiles);
+        HttpStatus status = dto.getDiaryId() == null ? HttpStatus.CREATED : HttpStatus.OK;
+        return ResponseEntity.status(status).body(dto);
     }
 }

--- a/src/main/java/com/konnect/diary/controller/DiaryController.java
+++ b/src/main/java/com/konnect/diary/controller/DiaryController.java
@@ -1,11 +1,13 @@
 package com.konnect.diary.controller;
 
-import com.konnect.diary.dto.CreateDiaryRequestDTO;
+import com.konnect.auth.dto.CustomUserPrincipal;
+import com.konnect.diary.dto.CreateDiaryDraftRequestDTO;
 import com.konnect.diary.dto.CreateDiaryResponseDTO;
 import com.konnect.diary.service.DiaryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,13 +21,16 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
-    @PostMapping("/user/diary")
+    @PostMapping("/user/diaries/draft")
     @ResponseBody
-    public ResponseEntity<CreateDiaryResponseDTO> createDiary(
-            @RequestPart("data") CreateDiaryRequestDTO requestDTO,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images
+    public ResponseEntity<CreateDiaryResponseDTO> createDiaryDraft(
+            @RequestPart("data") CreateDiaryDraftRequestDTO requestDTO,
+            @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @AuthenticationPrincipal CustomUserPrincipal userDetails
     ) {
-        CreateDiaryResponseDTO response = diaryService.createDiary(requestDTO, images);
+        requestDTO.setUserId(userDetails.getId());
+        CreateDiaryResponseDTO response = diaryService.createDiaryDraft(requestDTO, thumbnail, images);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/com/konnect/diary/dto/CreateDiaryDraftRequestDTO.java
+++ b/src/main/java/com/konnect/diary/dto/CreateDiaryDraftRequestDTO.java
@@ -10,19 +10,14 @@ import java.util.Optional;
 
 @Getter
 @Setter
-@NoArgsConstructor()
-@AllArgsConstructor
-@Builder
 @ToString
-public class CreateDiaryRequestDTO {
+public class CreateDiaryDraftRequestDTO {
+    private Optional<Long> diaryId = Optional.empty();
+
     @NotBlank
     private String title;
 
-    @NotBlank
     private Long userId;
-
-    @NotBlank
-    private String status;
 
     private Optional<String> content = Optional.empty();
 

--- a/src/main/java/com/konnect/diary/dto/CreateDiaryResponseDTO.java
+++ b/src/main/java/com/konnect/diary/dto/CreateDiaryResponseDTO.java
@@ -24,9 +24,10 @@ public class CreateDiaryResponseDTO {
     private String endDate;
     private List<TagResponseDTO> tags;
 
-    private List<String> imageCodes;
+    private String thumbnailImage;
+    private List<String> images;
 
-    public static CreateDiaryResponseDTO from(DiaryEntity diary, List<String> imageCodes) {
+    public static CreateDiaryResponseDTO from(DiaryEntity diary, String thumbnailImage, List<String> images) {
         List<TagResponseDTO> tagResponses = new ArrayList<>();
         for (DiaryTagEntity diaryTag : diary.getTags()) {
             tagResponses.add(TagResponseDTO.from(diaryTag.getTag()));
@@ -40,7 +41,8 @@ public class CreateDiaryResponseDTO {
                 diary.getStartDate(),
                 diary.getEndDate(),
                 tagResponses,
-                imageCodes
+                thumbnailImage,
+                images
         );
     }
 }

--- a/src/main/java/com/konnect/diary/entity/DiaryEntity.java
+++ b/src/main/java/com/konnect/diary/entity/DiaryEntity.java
@@ -5,13 +5,15 @@ import com.konnect.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "diaries")
 public class DiaryEntity {
 
@@ -21,7 +23,7 @@ public class DiaryEntity {
     private Long diaryId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,9 +33,6 @@ public class DiaryEntity {
     private String title;
 
     private String content;
-//TODO
-//    @Column(name = "image_total_count")
-//    private Integer imageTotalCount;
 
     @Column(name = "start_date")
     private String startDate;
@@ -44,30 +43,18 @@ public class DiaryEntity {
     @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
     private List<DiaryTagEntity> tags = new ArrayList<>();
 
+    @Column(nullable = false)
     private String status;
+
+    @Column(
+            name = "created_at",
+            nullable = false,
+            insertable = false,
+            updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+    )
+    private LocalDateTime createdAt;
 
     // TODO: 여행 루트 컬럼 추가 예정
 
-    @Builder
-    public DiaryEntity(
-            UserEntity user,
-            AreaEntity area,
-            String title,
-            String content,
-//            Integer imageTotalCount,
-            String startDate,
-            String endDate,
-            List<DiaryTagEntity> tags,
-            String status
-    ) {
-        this.user = user;
-        this.area = area;
-        this.title = title;
-        this.content = content;
-//        this.imageTotalCount = imageTotalCount;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.tags = tags;
-        this.status = status;
-    }
 }

--- a/src/main/java/com/konnect/diary/repository/DiaryTagRepository.java
+++ b/src/main/java/com/konnect/diary/repository/DiaryTagRepository.java
@@ -1,7 +1,14 @@
 package com.konnect.diary.repository;
 
+import com.konnect.diary.entity.DiaryEntity;
 import com.konnect.diary.entity.DiaryTagEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DiaryTagRepository extends JpaRepository<DiaryTagEntity, Long> {
+    @Modifying
+    @Query("DELETE FROM DiaryTagEntity dt WHERE dt.diary = :diary")
+    void deleteByDiary(@Param("diary") DiaryEntity diary);
 }

--- a/src/main/java/com/konnect/diary/service/DiaryService.java
+++ b/src/main/java/com/konnect/diary/service/DiaryService.java
@@ -1,6 +1,6 @@
 package com.konnect.diary.service;
 
-import com.konnect.diary.dto.CreateDiaryRequestDTO;
+import com.konnect.diary.dto.CreateDiaryDraftRequestDTO;
 import com.konnect.diary.dto.CreateDiaryResponseDTO;
 //import com.konnect.dto.ListDiaryResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
@@ -8,7 +8,9 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public interface DiaryService {
-    CreateDiaryResponseDTO createDiary(CreateDiaryRequestDTO requestDTO, List<MultipartFile> imageFiles);
-
-//    List<ListDiaryResponseDTO> fetchDiaryList();
+    CreateDiaryResponseDTO createDiaryDraft(
+            CreateDiaryDraftRequestDTO requestDTO,
+            MultipartFile thumbnail,
+            List<MultipartFile> imageFiles
+    );
 }

--- a/src/main/java/com/konnect/diary/service/exception/DiaryRuntimeException.java
+++ b/src/main/java/com/konnect/diary/service/exception/DiaryRuntimeException.java
@@ -1,0 +1,7 @@
+package com.konnect.diary.service.exception;
+
+public class DiaryRuntimeException extends RuntimeException {
+    public DiaryRuntimeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/konnect/util/FileStorage.java
+++ b/src/main/java/com/konnect/util/FileStorage.java
@@ -2,7 +2,8 @@ package com.konnect.util;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface FileStorage {
-    void save(Long diaryId, String fileName, MultipartFile file);
-    public void deleteDirectoryIfExists(Long postId);
+    public void saveAll(Long diaryId, MultipartFile thumbnail, List<MultipartFile> imageFiles);
 }

--- a/src/main/java/com/konnect/util/ImageManager.java
+++ b/src/main/java/com/konnect/util/ImageManager.java
@@ -12,19 +12,11 @@ public class ImageManager {
 
     private final FileStorage fileStorage;
 
-    public void saveImages(Long postId, List<MultipartFile> imageFiles) {
-        if (imageFiles == null || imageFiles.isEmpty()) return;
-
-        fileStorage.deleteDirectoryIfExists(postId);
-
-        for (int i = 0; i < imageFiles.size(); i++) {
-            MultipartFile image = imageFiles.get(i);
-            String filename = (i + 1) + getExtension(image.getOriginalFilename());
-            fileStorage.save(postId, filename, image);
-        }
-    }
-
-    private String getExtension(String filename) {
-        return filename.substring(filename.lastIndexOf("."));
+    public void saveAllImages(
+            Long diaryId,
+            MultipartFile thumbnail,
+            List<MultipartFile> imageFiles
+    ) {
+        fileStorage.saveAll(diaryId, thumbnail, imageFiles);
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed: #12

## 주요 변경 사항
- 기존 다이어리 생성 로직을 삭제하고, 임시저장 API를 추가했습니다.
  - diaryId를 request에 추가하면 수정, 추가하지 않으면 새로운 작성중 다이어리를 생성합니다.
- 기존 태그들을 삭제하고, 새로운 태그로 엎어치는 로직을 추가했습니다.
- 

### Request 요청 방법
- JWT 토큰이 필요합니다.
1. 다이어리에 추가할 내용을 json 형식을 data Key에 추가
2. 다이어리에 추가할 썸네일을 thumbnail Key에 Multipart로 추가합니다.
3. 다이어리에 추가할 이미지 파일들을 images Key에 Multipart 배열로 추가합니다.

### 수정 전 저장 방식

```
var/
└── konnect/
    └── images/
        ├── 1/
        │   ├── 1.jpg
        │   └── 2.jpg
        ├── 2/
        │   ├── 1.jpg
        │   └── 2.jpg
        └── 3/
            ├── 1.jpg
            └── 2.jpg

```

### 수정 후 저장 방식
```
var/
└── konnect/
    └── images/
        ├── 1/
        |   ├── thumbnail.jpg
        |   ├── images/
             │   ├── 1.jpg
             │   ├── 2.jpg
             │   └── 3.jpg
// ...
```