### PR TITLE
다이어리 생성 기능 추가

### DIFF
--- a/src/main/java/com/konnect/diary/controller/DiaryController.java
+++ b/src/main/java/com/konnect/diary/controller/DiaryController.java
@@ -4,8 +4,16 @@ import com.konnect.auth.dto.CustomUserPrincipal;
 import com.konnect.diary.dto.CreateDiaryDraftRequestDTO;
 import com.konnect.diary.dto.CreateDiaryResponseDTO;
 import com.konnect.diary.service.DiaryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -21,16 +29,60 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
-    @PostMapping("/user/diaries/draft")
+    @Operation(
+            summary = "임시저장 다이어리 생성/수정",
+            description = "드래프트(draft) 상태인 다이어리를 생성하거나 업데이트합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "드래프트 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CreateDiaryResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "드래프트 생성 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CreateDiaryResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력값", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PostMapping(path = "/user/diaries/draft")
     @ResponseBody
-    public ResponseEntity<CreateDiaryResponseDTO> createDiaryDraft(
+    public ResponseEntity<CreateDiaryResponseDTO> saveDraft(
+            @Parameter(
+                    description = "드래프트 저장 요청 DTO",
+                    required = true,
+                    schema = @Schema(implementation = CreateDiaryDraftRequestDTO.class)
+            )
             @RequestPart("data") CreateDiaryDraftRequestDTO requestDTO,
+
+            @Parameter(
+                    description = "썸네일 이미지 파일 (optional)",
+                    in = ParameterIn.HEADER,
+                    content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+            )
             @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+
+            @Parameter(
+                    description = "본문 이미지 파일 목록, 최대 9장 (optional)",
+                    in = ParameterIn.HEADER,
+                    content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+            )
+            @RequestPart(value = "images", required = false) List<MultipartFile> imageFiles,
+
             @AuthenticationPrincipal CustomUserPrincipal userDetails
     ) {
         requestDTO.setUserId(userDetails.getId());
-        CreateDiaryResponseDTO response = diaryService.createDiaryDraft(requestDTO, thumbnail, images);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        CreateDiaryResponseDTO dto =
+                diaryService.createDiaryDraft(requestDTO, thumbnail, imageFiles);
+        HttpStatus status = dto.getDiaryId() == null ? HttpStatus.CREATED : HttpStatus.OK;
+        return ResponseEntity.status(status).body(dto);
     }
 }

--- a/src/main/java/com/konnect/diary/controller/DiaryController.java
+++ b/src/main/java/com/konnect/diary/controller/DiaryController.java
@@ -1,11 +1,13 @@
 package com.konnect.diary.controller;
 
-import com.konnect.diary.dto.CreateDiaryRequestDTO;
+import com.konnect.auth.dto.CustomUserPrincipal;
+import com.konnect.diary.dto.CreateDiaryDraftRequestDTO;
 import com.konnect.diary.dto.CreateDiaryResponseDTO;
 import com.konnect.diary.service.DiaryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,13 +21,16 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
-    @PostMapping("/user/diary")
+    @PostMapping("/user/diaries/draft")
     @ResponseBody
-    public ResponseEntity<CreateDiaryResponseDTO> createDiary(
-            @RequestPart("data") CreateDiaryRequestDTO requestDTO,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images
+    public ResponseEntity<CreateDiaryResponseDTO> createDiaryDraft(
+            @RequestPart("data") CreateDiaryDraftRequestDTO requestDTO,
+            @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @AuthenticationPrincipal CustomUserPrincipal userDetails
     ) {
-        CreateDiaryResponseDTO response = diaryService.createDiary(requestDTO, images);
+        requestDTO.setUserId(userDetails.getId());
+        CreateDiaryResponseDTO response = diaryService.createDiaryDraft(requestDTO, thumbnail, images);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/com/konnect/diary/controller/DiaryController.java
+++ b/src/main/java/com/konnect/diary/controller/DiaryController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 
 @Controller
 @RequiredArgsConstructor
@@ -82,6 +83,42 @@ public class DiaryController {
         requestDTO.setUserId(userDetails.getId());
         CreateDiaryResponseDTO dto =
                 diaryService.createDiaryDraft(requestDTO, thumbnail, imageFiles);
+        HttpStatus status = dto.getDiaryId() == null ? HttpStatus.CREATED : HttpStatus.OK;
+        return ResponseEntity.status(status).body(dto);
+    }
+
+    @PostMapping("/user/diaries/{diaryId}/publish")
+    @ResponseBody
+    public ResponseEntity<CreateDiaryResponseDTO> publishDiary(
+            @PathVariable Long diaryId,
+
+            @Parameter(
+                    description = "다이어리 게시 요청 DTO",
+                    required = true,
+                    schema = @Schema(implementation = CreateDiaryDraftRequestDTO.class)
+            )
+            @RequestPart("data") CreateDiaryDraftRequestDTO requestDTO,
+
+            @Parameter(
+                    description = "썸네일 이미지 파일 (optional)",
+                    in = ParameterIn.HEADER,
+                    content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+            )
+            @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail,
+
+            @Parameter(
+                    description = "본문 이미지 파일 목록, 최대 9장 (optional)",
+                    in = ParameterIn.HEADER,
+                    content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+            )
+            @RequestPart(value = "images", required = false) List<MultipartFile> imageFiles,
+
+            @AuthenticationPrincipal CustomUserPrincipal userDetails
+    ) {
+        requestDTO.setUserId(userDetails.getId());
+        requestDTO.setDiaryId(Optional.ofNullable(diaryId));
+        CreateDiaryResponseDTO dto =
+                diaryService.publishDraft(requestDTO, thumbnail, imageFiles);
         HttpStatus status = dto.getDiaryId() == null ? HttpStatus.CREATED : HttpStatus.OK;
         return ResponseEntity.status(status).body(dto);
     }

--- a/src/main/java/com/konnect/diary/dto/CreateDiaryDraftRequestDTO.java
+++ b/src/main/java/com/konnect/diary/dto/CreateDiaryDraftRequestDTO.java
@@ -10,19 +10,14 @@ import java.util.Optional;
 
 @Getter
 @Setter
-@NoArgsConstructor()
-@AllArgsConstructor
-@Builder
 @ToString
-public class CreateDiaryRequestDTO {
+public class CreateDiaryDraftRequestDTO {
+    private Optional<Long> diaryId = Optional.empty();
+
     @NotBlank
     private String title;
 
-    @NotBlank
     private Long userId;
-
-    @NotBlank
-    private String status;
 
     private Optional<String> content = Optional.empty();
 

--- a/src/main/java/com/konnect/diary/dto/CreateDiaryResponseDTO.java
+++ b/src/main/java/com/konnect/diary/dto/CreateDiaryResponseDTO.java
@@ -24,9 +24,10 @@ public class CreateDiaryResponseDTO {
     private String endDate;
     private List<TagResponseDTO> tags;
 
-    private List<String> imageCodes;
+    private String thumbnailImage;
+    private List<String> images;
 
-    public static CreateDiaryResponseDTO from(DiaryEntity diary, List<String> imageCodes) {
+    public static CreateDiaryResponseDTO from(DiaryEntity diary, String thumbnailImage, List<String> images) {
         List<TagResponseDTO> tagResponses = new ArrayList<>();
         for (DiaryTagEntity diaryTag : diary.getTags()) {
             tagResponses.add(TagResponseDTO.from(diaryTag.getTag()));
@@ -40,7 +41,8 @@ public class CreateDiaryResponseDTO {
                 diary.getStartDate(),
                 diary.getEndDate(),
                 tagResponses,
-                imageCodes
+                thumbnailImage,
+                images
         );
     }
 }

--- a/src/main/java/com/konnect/diary/entity/DiaryEntity.java
+++ b/src/main/java/com/konnect/diary/entity/DiaryEntity.java
@@ -5,13 +5,15 @@ import com.konnect.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "diaries")
 public class DiaryEntity {
 
@@ -21,7 +23,7 @@ public class DiaryEntity {
     private Long diaryId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,9 +33,6 @@ public class DiaryEntity {
     private String title;
 
     private String content;
-//TODO
-//    @Column(name = "image_total_count")
-//    private Integer imageTotalCount;
 
     @Column(name = "start_date")
     private String startDate;
@@ -44,30 +43,18 @@ public class DiaryEntity {
     @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
     private List<DiaryTagEntity> tags = new ArrayList<>();
 
+    @Column(nullable = false)
     private String status;
+
+    @Column(
+            name = "created_at",
+            nullable = false,
+            insertable = false,
+            updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+    )
+    private LocalDateTime createdAt;
 
     // TODO: 여행 루트 컬럼 추가 예정
 
-    @Builder
-    public DiaryEntity(
-            UserEntity user,
-            AreaEntity area,
-            String title,
-            String content,
-//            Integer imageTotalCount,
-            String startDate,
-            String endDate,
-            List<DiaryTagEntity> tags,
-            String status
-    ) {
-        this.user = user;
-        this.area = area;
-        this.title = title;
-        this.content = content;
-//        this.imageTotalCount = imageTotalCount;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.tags = tags;
-        this.status = status;
-    }
 }

--- a/src/main/java/com/konnect/diary/repository/DiaryTagRepository.java
+++ b/src/main/java/com/konnect/diary/repository/DiaryTagRepository.java
@@ -1,7 +1,14 @@
 package com.konnect.diary.repository;
 
+import com.konnect.diary.entity.DiaryEntity;
 import com.konnect.diary.entity.DiaryTagEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DiaryTagRepository extends JpaRepository<DiaryTagEntity, Long> {
+    @Modifying
+    @Query("DELETE FROM DiaryTagEntity dt WHERE dt.diary = :diary")
+    void deleteByDiary(@Param("diary") DiaryEntity diary);
 }

--- a/src/main/java/com/konnect/diary/service/DiaryService.java
+++ b/src/main/java/com/konnect/diary/service/DiaryService.java
@@ -13,4 +13,9 @@ public interface DiaryService {
             MultipartFile thumbnail,
             List<MultipartFile> imageFiles
     );
+    CreateDiaryResponseDTO publishDraft(
+            CreateDiaryDraftRequestDTO dto,
+            MultipartFile thumbnail,
+            List<MultipartFile> imageFiles
+    );
 }

--- a/src/main/java/com/konnect/diary/service/DiaryService.java
+++ b/src/main/java/com/konnect/diary/service/DiaryService.java
@@ -1,6 +1,6 @@
 package com.konnect.diary.service;
 
-import com.konnect.diary.dto.CreateDiaryRequestDTO;
+import com.konnect.diary.dto.CreateDiaryDraftRequestDTO;
 import com.konnect.diary.dto.CreateDiaryResponseDTO;
 //import com.konnect.dto.ListDiaryResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
@@ -8,7 +8,9 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public interface DiaryService {
-    CreateDiaryResponseDTO createDiary(CreateDiaryRequestDTO requestDTO, List<MultipartFile> imageFiles);
-
-//    List<ListDiaryResponseDTO> fetchDiaryList();
+    CreateDiaryResponseDTO createDiaryDraft(
+            CreateDiaryDraftRequestDTO requestDTO,
+            MultipartFile thumbnail,
+            List<MultipartFile> imageFiles
+    );
 }

--- a/src/main/java/com/konnect/diary/service/DiaryServiceImpl.java
+++ b/src/main/java/com/konnect/diary/service/DiaryServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -38,79 +39,90 @@ public class DiaryServiceImpl implements DiaryService {
     @Override
     @Transactional
     public CreateDiaryResponseDTO createDiaryDraft(
-            CreateDiaryDraftRequestDTO requestDTO,
+            CreateDiaryDraftRequestDTO dto,
             MultipartFile thumbnail,
             List<MultipartFile> imageFiles
     ) {
-        DiaryEntity diary = requestDTO.getDiaryId()
-                .map(id -> diaryRepository.findById(id)
-                        .filter(d -> "editing".equals(d.getStatus()))
-                        .orElseThrow(() -> new DiaryRuntimeException("Draft not found for id: " + id))
-                )
-                .orElseGet(DiaryEntity::new);
+        return upsertAndSaveDraft(dto, thumbnail, imageFiles, false);
+    }
+
+    @Override
+    @Transactional
+    public CreateDiaryResponseDTO publishDraft(
+            CreateDiaryDraftRequestDTO dto,
+            MultipartFile thumbnail,
+            List<MultipartFile> imageFiles
+    ) {
+        return upsertAndSaveDraft(dto, thumbnail, imageFiles, true);
+    }
+
+    private CreateDiaryResponseDTO upsertAndSaveDraft(
+            CreateDiaryDraftRequestDTO dto,
+            MultipartFile thumbnail,
+            List<MultipartFile> imageFiles,
+            boolean publish
+    ) {
+        if (publish && dto.getDiaryId() == null) {
+            throw new DiaryRuntimeException("Cannot publish: draftId must be provided");
+        }
+
+        DiaryEntity diary;
+        if (dto.getDiaryId().isPresent()) {
+            Long id = dto.getDiaryId().get();
+            DiaryEntity existing = diaryRepository.findById(id)
+                    .orElseThrow(() -> new DiaryRuntimeException(
+                            "Draft not found: " + id));
+
+            if ("published".equals(existing.getStatus())) {
+                throw new DiaryRuntimeException(
+                        "Cannot modify a published diary: " + id);
+            }
+
+            if (!"editing".equals(existing.getStatus())) {
+                throw new DiaryRuntimeException(
+                        "Draft is not in an editable state: " + id);
+            }
+
+            diary = existing;
+        } else {
+            diary = new DiaryEntity();
+        }
+
+        diary.setUser(userRepository.getReferenceById(dto.getUserId()));
+        diary.setTitle(dto.getTitle());
+        diary.setContent(dto.getContent().orElse(null));
+        diary.setArea(dto.getAreaId()
+                .map(areaRepository::getReferenceById)
+                .orElse(null));
+        diary.setStartDate(dto.getStartDate().orElse(null));
+        diary.setEndDate(dto.getEndDate().orElse(null));
+        String status = publish ? "published" : "editing";
+        diary.setStatus(status);
+        diary = diaryRepository.save(diary);
+        syncTags(diary, dto.getTags());
+
+        byte[] thumbBytes = readBytesOrNull(thumbnail,    "thumbnail");
+        List<byte[]> imgBytes = readBytesList(imageFiles, "image");
 
         try {
-            diary.setTitle(requestDTO.getTitle());
-            diary.setContent(requestDTO.getContent().orElse(null));
-            diary.setArea(requestDTO.getAreaId()
-                    .map(areaRepository::getReferenceById)
-                    .orElse(null)
-            );
-            diary.setStartDate(requestDTO.getStartDate().orElse(null));
-            diary.setEndDate(requestDTO.getEndDate().orElse(null));
-            diary.setStatus("editing");
-            Long userId = requestDTO.getUserId();
-            diary.setUser(userRepository.getReferenceById(userId));
-
-            diary = diaryRepository.save(diary);
-            syncTags(diary, requestDTO.getTags());
-
-            byte[] thumbBytes = null;
-            if (thumbnail != null && !thumbnail.isEmpty()) {
-                try {
-                    thumbBytes = thumbnail.getBytes();
-                } catch (IOException e) {
-                    throw new DiaryRuntimeException("Failed to read thumbnail bytes");
-                }
-            }
-
-            List<byte[]> imagesBytes = new ArrayList<>();
-            if (imageFiles != null) {
-                for (int i = 0; i < Math.min(imageFiles.size(), 9); i++) {
-                    MultipartFile mf = imageFiles.get(i);
-                    if (mf.isEmpty()) continue;
-                    try {
-                        imagesBytes.add(mf.getBytes());
-                    } catch (IOException e) {
-                        throw new DiaryRuntimeException("Failed to read image bytes");
-                    }
-                }
-            }
-
-            try {
-                imageManager.saveAllImages(diary.getDiaryId(), thumbnail, imageFiles);
-            } catch (Exception ex) {
-                throw new DiaryRuntimeException(
-                        "Failed to store images for diary " + diary.getDiaryId());
-            }
-
-            String thumbnailBase64 = null;
-            if (thumbBytes != null) {
-                String prefix = "data:" + thumbnail.getContentType() + ";base64,";
-                thumbnailBase64 = prefix + Base64.getEncoder()
-                        .encodeToString(thumbBytes);
-            }
-            List<String> imagesBase64 = imagesBytes.stream()
-                    .map(bytes -> "data:image/*;base64," +
-                            Base64.getEncoder().encodeToString(bytes))
-                    .collect(Collectors.toList());
-
-            return CreateDiaryResponseDTO.from(diary, thumbnailBase64, imagesBase64);
+            imageManager.saveAllImages(diary.getDiaryId(), thumbnail, imageFiles);
         } catch (Exception ex) {
-            throw new DiaryRuntimeException(
-                    "Failed to create or update diary draft: " + ex.getMessage()
-            );
+            throw new DiaryRuntimeException("Failed to store images for diary " + diary.getDiaryId());
         }
+
+        if (publish) {
+            validateForPublish(diary, thumbnail, imageFiles);
+            diary.setStatus("published");
+            diary.setCreatedAt(LocalDateTime.now());
+            diary = diaryRepository.save(diary);
+        }
+
+        String thumbBase64 = toBase64(thumbnail, thumbBytes);
+        List<String> imgsBase64 = imgBytes.stream()
+                .map(b -> "data:image/*;base64," + Base64.getEncoder().encodeToString(b))
+                .collect(Collectors.toList());
+
+        return CreateDiaryResponseDTO.from(diary, thumbBase64, imgsBase64);
     }
 
     private void syncTags(DiaryEntity diary, List<Long> tagIds) {
@@ -134,4 +146,48 @@ public class DiaryServiceImpl implements DiaryService {
         }
     }
 
+    private void validateForPublish(
+            DiaryEntity diary,
+            MultipartFile thumbnail,
+            List<MultipartFile> imageFiles
+    ) {
+        if (diary.getTitle() == null || diary.getTitle().isBlank()
+                || diary.getArea() == null
+                || diary.getContent() == null || diary.getContent().isBlank()
+                || diary.getTags().isEmpty()
+                || diary.getStartDate() == null || diary.getEndDate() == null
+        ) {
+            throw new DiaryRuntimeException("Cannot publish: missing required fields");
+        }
+    }
+
+    private byte[] readBytesOrNull(MultipartFile file, String who) {
+        if (file == null || file.isEmpty()) return null;
+        try {
+            return file.getBytes();
+        } catch (IOException e) {
+            throw new DiaryRuntimeException("Failed to read " + who + " bytes");
+        }
+    }
+
+    private List<byte[]> readBytesList(List<MultipartFile> files, String who) {
+        if (files == null) return List.of();
+        List<byte[]> list = new ArrayList<>();
+        for (int i = 0; i < Math.min(files.size(), 9); i++) {
+            MultipartFile mf = files.get(i);
+            if (mf.isEmpty()) continue;
+            try {
+                list.add(mf.getBytes());
+            } catch (IOException e) {
+                throw new DiaryRuntimeException("Failed to read " + who + " bytes");
+            }
+        }
+        return list;
+    }
+
+    private String toBase64(MultipartFile file, byte[] bytes) {
+        if (bytes == null) return null;
+        String prefix = "data:" + file.getContentType() + ";base64,";
+        return prefix + Base64.getEncoder().encodeToString(bytes);
+    }
 }

--- a/src/main/java/com/konnect/diary/service/exception/DiaryRuntimeException.java
+++ b/src/main/java/com/konnect/diary/service/exception/DiaryRuntimeException.java
@@ -1,0 +1,7 @@
+package com.konnect.diary.service.exception;
+
+public class DiaryRuntimeException extends RuntimeException {
+    public DiaryRuntimeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/konnect/util/FileStorage.java
+++ b/src/main/java/com/konnect/util/FileStorage.java
@@ -2,7 +2,8 @@ package com.konnect.util;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface FileStorage {
-    void save(Long diaryId, String fileName, MultipartFile file);
-    public void deleteDirectoryIfExists(Long postId);
+    public void saveAll(Long diaryId, MultipartFile thumbnail, List<MultipartFile> imageFiles);
 }

--- a/src/main/java/com/konnect/util/ImageManager.java
+++ b/src/main/java/com/konnect/util/ImageManager.java
@@ -12,19 +12,11 @@ public class ImageManager {
 
     private final FileStorage fileStorage;
 
-    public void saveImages(Long postId, List<MultipartFile> imageFiles) {
-        if (imageFiles == null || imageFiles.isEmpty()) return;
-
-        fileStorage.deleteDirectoryIfExists(postId);
-
-        for (int i = 0; i < imageFiles.size(); i++) {
-            MultipartFile image = imageFiles.get(i);
-            String filename = (i + 1) + getExtension(image.getOriginalFilename());
-            fileStorage.save(postId, filename, image);
-        }
-    }
-
-    private String getExtension(String filename) {
-        return filename.substring(filename.lastIndexOf("."));
+    public void saveAllImages(
+            Long diaryId,
+            MultipartFile thumbnail,
+            List<MultipartFile> imageFiles
+    ) {
+        fileStorage.saveAll(diaryId, thumbnail, imageFiles);
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed: #14

## 주요 변경 사항
- 다이어리를 게시하는 API를 추가했습니다.
  - 임시저장된 다이어리를 게시하거나, 새로운 다이어리를 게시합니다.

### 에러 처리
1. 이미 게시된 다이어리일 경우, 에러를 던집니다.
2. 해당 ID의 다이어리가 존재하지 않으면, 에러를 던집니다.

### Request 요청 방법
- JWT 토큰이 필요합니다.
POST http://localhost:8080/api/v1/user/diaries/{diary_id}/publish
1. 다이어리에 추가할 내용을 json 형식을 data Key에 추가
4. 다이어리에 추가할 썸네일을 thumbnail Key에 Multipart로 추가합니다.
5. 다이어리에 추가할 이미지 파일들을 images Key에 Multipart 배열로 추가합니다.