### PR TITLE
여행경로 CRUD 구현

### DIFF
--- a/src/main/java/com/konnect/auth/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/konnect/auth/oauth2/CustomSuccessHandler.java
@@ -55,7 +55,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     }
 
     private String getRedirectURL(HttpServletRequest request, HttpServletResponse response) {
-        String redirectUri = "";
+        String redirectUri = "http://localhost:8080";
 
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {

--- a/src/main/java/com/konnect/auth/service/SignUpService.java
+++ b/src/main/java/com/konnect/auth/service/SignUpService.java
@@ -33,9 +33,8 @@ public class SignUpService {
         if (userRepository.existsByEmail(email)) {
             throw new SignUpRuntimeException(SignUpError.DUPLICATE_EMAIL);
         }
-
-        if (userRepository.existsByName(name)) {
-            throw new SignUpRuntimeException(SignUpError.DUPLICATE_USERNAME);
-        }
+//        if (userRepository.existsByName(name)) {
+//            throw new SignUpRuntimeException(SignUpError.DUPLICATE_USERNAME);
+//        }
     }
 }

--- a/src/main/java/com/konnect/route/controller/RouteController.java
+++ b/src/main/java/com/konnect/route/controller/RouteController.java
@@ -1,0 +1,140 @@
+package com.konnect.route.controller;
+
+import com.konnect.auth.dto.CustomUserPrincipal;
+import com.konnect.route.dto.RouteCreateRequest;
+import com.konnect.route.dto.RouteResponse;
+import com.konnect.route.dto.RouteUpdateRequest;
+import com.konnect.route.service.RouteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/user/routes")
+@RequiredArgsConstructor
+@Tag(name = "여행 경로", description = "다이어리에 포함된 여행 루트 CRUD API")
+public class RouteController {
+
+    private final RouteService routeService;
+
+    @Operation(
+            summary = "루트 생성",
+            description = """
+                • 자신의 다이어리(diaryId)에 새 방문 루트를 등록합니다.
+                • <code>orderIdx</code> 를 생략하면 서버가 자동으로 다음 순번을 부여합니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 성공",
+                    content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 diaryId 또는 attractionNo",
+                    content = @Content)
+    })
+    @PostMapping
+    public ResponseEntity<Long> create(
+            @Valid @RequestBody @Parameter(description = "루트 생성 요청 본문", required = true)
+            RouteCreateRequest req,
+            @AuthenticationPrincipal
+            CustomUserPrincipal userDetails
+    ) {
+        return ResponseEntity.ok(routeService.create(req, userDetails.getId()));
+    }
+
+
+    @Operation(
+            summary = "루트 목록 조회",
+            description = "특정 다이어리의 루트들을 순서(idx) 오름차순으로 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = RouteResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 diaryId",
+                    content = @Content)
+    })
+    @GetMapping
+    public ResponseEntity<List<RouteResponse>> list(
+            @Parameter(description = "다이어리 PK", required = true, example = "3")
+            @RequestParam Long diaryId) {
+
+        return ResponseEntity.ok(routeService.listByDiary(diaryId));
+    }
+
+
+    @Operation(
+            summary = "루트 수정",
+            description = """
+                • <code>visitedAt</code>, <code>orderIdx</code>, <code>attractionNo</code> 중 필요한 필드만 전송해 부분 수정이 가능합니다.  
+                • <code>orderIdx</code> 를 변경하면 같은 다이어리 내 순서를 재배치해야 합니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 id / attraction", content = @Content)
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(
+            @Parameter(description = "루트 PK", required = true, example = "10")
+            @PathVariable Long id,
+
+            @Valid @RequestBody
+            @Parameter(description = "루트 수정 요청 본문", required = true)
+            RouteUpdateRequest req) {
+
+        routeService.update(id, req);
+        return ResponseEntity.ok().build();
+    }
+
+
+    @Operation(summary = "루트 삭제", description = "PK(id)로 단일 루트를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 id", content = @Content)
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(
+            @Parameter(description = "루트 PK", required = true, example = "10")
+            @PathVariable Long id) {
+
+        routeService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+
+    @Operation(
+            summary = "루트 순서 재정렬",
+            description = """
+                • 프론트에서 새 순서대로 정렬한 <code>routeId</code> 리스트를 보내면 서버가 일괄 업데이트합니다.  
+                • 응답은 단순 200 OK입니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "재정렬 성공"),
+            @ApiResponse(responseCode = "400", description = "리스트 비어 있음 / 서로 다른 diaryId 포함", content = @Content)
+    })
+    @PostMapping("/reorder")
+    public ResponseEntity<Void> reorder(
+            @Parameter(
+                    description = "재정렬된 Route PK 리스트",
+                    required = true,
+                    example = "[12, 15, 10, 11]"
+            )
+            @RequestBody List<Long> orderedRouteIds) {
+
+        int order = 1;
+        for (Long id : orderedRouteIds) {
+            routeService.update(id, new RouteUpdateRequest(null, order++, null));
+        }
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/konnect/route/dto/RouteCreateByDateRequest.java
+++ b/src/main/java/com/konnect/route/dto/RouteCreateByDateRequest.java
@@ -1,0 +1,27 @@
+package com.konnect.route.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Schema(description = "루트 생성 요청(방문 날짜만 제공)")
+@Builder
+public record RouteCreateByDateRequest(
+        @NotNull
+        @Schema(description = "관광지 PK", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer attractionNo,
+
+        @NotNull
+        @Schema(description = "다이어리 PK", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long diaryId,
+
+        @NotNull
+        @Schema(description = "방문 날짜(yyyy-MM-dd, 시간 미포함)", example = "2025-06-15",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        LocalDate visitedDate,
+
+        @Schema(description = "다이어리 내 방문 순서(생략 시 자동)", example = "3")
+        Integer orderIdx
+) { }

--- a/src/main/java/com/konnect/route/dto/RouteCreateRequest.java
+++ b/src/main/java/com/konnect/route/dto/RouteCreateRequest.java
@@ -1,0 +1,27 @@
+package com.konnect.route.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "루트 생성 요청")
+@Builder
+public record RouteCreateRequest(
+
+        @NotNull
+        @Schema(description = "관광지 PK (attractions.no)", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer attractionNo,
+
+        @NotNull
+        @Schema(description = "다이어리 PK", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long diaryId,
+
+        @NotNull
+        @Schema(description = "방문 일시(ISO-8601)", example = "2025-06-15T10:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
+        LocalDateTime visitedAt,
+
+        @Schema(description = "다이어리 내 방문 순서(생략 시 서버가 자동 채번)", example = "1")
+        Integer orderIdx
+) { }

--- a/src/main/java/com/konnect/route/dto/RouteDetailResponse.java
+++ b/src/main/java/com/konnect/route/dto/RouteDetailResponse.java
@@ -1,11 +1,12 @@
 package com.konnect.route.dto;
 
+import com.konnect.attraction.dto.AttractionDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(description = "루트 조회 응답")
-public record RouteResponse(
+@Schema(description = "루트 + 관광지 상세 응답")
+public record RouteDetailResponse(
 
         @Schema(description = "루트 PK", example = "10")
         Long id,
@@ -16,9 +17,6 @@ public record RouteResponse(
         @Schema(description = "방문 일시(ISO-8601)", example = "2025-06-15T10:30:00")
         LocalDateTime visitedAt,
 
-        @Schema(description = "관광지 PK", example = "123")
-        Integer attractionNo,
-
-        @Schema(description = "관광지 이름", example = "남산 서울타워")
-        String attractionTitle
+        @Schema(description = "관광지 상세 정보")
+        AttractionDTO attraction
 ) { }

--- a/src/main/java/com/konnect/route/dto/RouteResponse.java
+++ b/src/main/java/com/konnect/route/dto/RouteResponse.java
@@ -1,0 +1,24 @@
+package com.konnect.route.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "루트 조회 응답")
+public record RouteResponse(
+
+        @Schema(description = "루트 PK", example = "10")
+        Long id,
+
+        @Schema(description = "다이어리 내 방문 순서", example = "1")
+        Integer orderIdx,
+
+        @Schema(description = "방문 일시(ISO-8601)", example = "2025-06-15T10:30:00")
+        LocalDateTime visitedAt,
+
+        @Schema(description = "관광지 PK", example = "123")
+        Integer attractionNo,
+
+        @Schema(description = "관광지 이름", example = "남산 서울타워")
+        String attractionTitle
+) { }

--- a/src/main/java/com/konnect/route/dto/RouteUpdateRequest.java
+++ b/src/main/java/com/konnect/route/dto/RouteUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.konnect.route.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "루트 수정 요청(부분 업데이트 지원)")
+@Builder
+public record RouteUpdateRequest(
+
+        @Schema(description = "방문 일시(ISO-8601)", example = "2025-06-16T14:00:00")
+        LocalDateTime visitedAt,
+
+        @Schema(description = "새 방문 순서", example = "2")
+        Integer orderIdx,
+
+        @Schema(description = "변경할 관광지 PK", example = "321")
+        Integer attractionNo
+) { }

--- a/src/main/java/com/konnect/route/entity/Route.java
+++ b/src/main/java/com/konnect/route/entity/Route.java
@@ -1,0 +1,51 @@
+package com.konnect.route.entity;
+
+import com.konnect.attraction.entity.Attraction;
+import com.konnect.diary.entity.DiaryEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "routes",
+        uniqueConstraints = @UniqueConstraint(name = "uk_diary_idx", columnNames = {"diary_id", "idx"}))
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Route {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "no", nullable = false)
+    private Attraction attraction;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private DiaryEntity diary;
+
+    @Column(name = "idx", nullable = false)
+    private Integer orderIdx;
+
+    @Column(name = "`date`", nullable = false)
+    private LocalDateTime visitedAt;
+
+    public void updateOrder(int newOrder) {
+        this.orderIdx = newOrder;
+    }
+
+    public void updateVisitedAt(LocalDateTime dateTime) {
+        this.visitedAt = dateTime;
+    }
+
+    public void changeAttraction(Attraction attraction) {
+        this.attraction = attraction;
+    }
+}

--- a/src/main/java/com/konnect/route/repository/RouteRepository.java
+++ b/src/main/java/com/konnect/route/repository/RouteRepository.java
@@ -1,0 +1,12 @@
+package com.konnect.route.repository;
+
+import com.konnect.route.dto.RouteResponse;
+import com.konnect.route.entity.Route;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RouteRepository extends JpaRepository<Route, Long>, RouteRepositoryCustom {
+    List<Route> findByDiaryDiaryIdOrderByOrderIdxAsc(Long diaryId);
+}
+

--- a/src/main/java/com/konnect/route/repository/RouteRepository.java
+++ b/src/main/java/com/konnect/route/repository/RouteRepository.java
@@ -1,6 +1,5 @@
 package com.konnect.route.repository;
 
-import com.konnect.route.dto.RouteResponse;
 import com.konnect.route.entity.Route;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/konnect/route/repository/RouteRepositoryCustom.java
+++ b/src/main/java/com/konnect/route/repository/RouteRepositoryCustom.java
@@ -1,10 +1,12 @@
 package com.konnect.route.repository;
 
-import com.konnect.route.dto.RouteResponse;
+import com.konnect.route.dto.RouteDetailResponse;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface RouteRepositoryCustom {
     int nextOrderIdx(Long diaryId);
-    List<RouteResponse> searchByDiary(Long diaryId);
+    List<RouteDetailResponse> searchByDiary(Long diaryId);
+    List<RouteDetailResponse> searchByDiaryAndDate(Long diaryId, LocalDate date);
 }

--- a/src/main/java/com/konnect/route/repository/RouteRepositoryCustom.java
+++ b/src/main/java/com/konnect/route/repository/RouteRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.konnect.route.repository;
+
+import com.konnect.route.dto.RouteResponse;
+
+import java.util.List;
+
+public interface RouteRepositoryCustom {
+    int nextOrderIdx(Long diaryId);
+    List<RouteResponse> searchByDiary(Long diaryId);
+}

--- a/src/main/java/com/konnect/route/repository/RouteRepositoryImpl.java
+++ b/src/main/java/com/konnect/route/repository/RouteRepositoryImpl.java
@@ -1,12 +1,16 @@
 package com.konnect.route.repository;
 
+import com.konnect.attraction.dto.AttractionDTO;
 import com.konnect.attraction.entity.QAttraction;
-import com.konnect.route.dto.RouteResponse;
+import com.konnect.route.dto.RouteDetailResponse;
 import com.konnect.route.entity.QRoute;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -24,23 +28,70 @@ public class RouteRepositoryImpl implements RouteRepositoryCustom {
         return max == null ? 1 : max + 1;
     }
 
+    private Expression<AttractionDTO> attractionProjection(QAttraction a) {
+        // AttractionDTO(생성자) 파라미터 순서는 클래스 생성자와 동일해야 합니다.
+        return Projections.constructor(AttractionDTO.class,
+                a.no,
+                a.contentId,
+                a.title,
+                a.contentType.contentTypeId,
+                a.contentType.contentTypeName,
+                a.sido.sidoCode,
+                a.sido.sidoName,
+                a.gugun.gugunCode,
+                a.gugun.gugunName,
+                a.firstImage1,
+                a.firstImage2,
+                a.mapLevel,
+                a.latitude,
+                a.longitude,
+                a.tel,
+                a.addr1,
+                a.addr2,
+                a.homepage,
+                a.overview
+        );
+    }
+
     @Override
-    public List<RouteResponse> searchByDiary(Long diaryId) {
+    public List<RouteDetailResponse> searchByDiary(Long diaryId) {
         QRoute r = QRoute.route;
         QAttraction a = QAttraction.attraction;
 
         return query
-                .select(Projections.constructor(RouteResponse.class,
+                .select(Projections.constructor(RouteDetailResponse.class,
                         r.id,
                         r.orderIdx,
                         r.visitedAt,
-                        a.no,
-                        a.title
+                        attractionProjection(a)
                 ))
                 .from(r)
                 .join(r.attraction, a)
                 .where(r.diary.diaryId.eq(diaryId))
                 .orderBy(r.orderIdx.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<RouteDetailResponse> searchByDiaryAndDate(Long diaryId, LocalDate date) {
+        QRoute r = QRoute.route;
+        QAttraction a = QAttraction.attraction;
+
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.plusDays(1).atStartOfDay().minusNanos(1);
+
+        return query
+                .select(Projections.constructor(RouteDetailResponse.class,
+                        r.id,
+                        r.orderIdx,
+                        r.visitedAt,
+                        attractionProjection(a)
+                ))
+                .from(r)
+                .join(r.attraction, a)
+                .where(r.diary.diaryId.eq(diaryId)
+                        .and(r.visitedAt.between(start, end)))
+                .orderBy(r.visitedAt.asc())
                 .fetch();
     }
 }

--- a/src/main/java/com/konnect/route/repository/RouteRepositoryImpl.java
+++ b/src/main/java/com/konnect/route/repository/RouteRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.konnect.route.repository;
+
+import com.konnect.attraction.entity.QAttraction;
+import com.konnect.route.dto.RouteResponse;
+import com.konnect.route.entity.QRoute;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class RouteRepositoryImpl implements RouteRepositoryCustom {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public int nextOrderIdx(Long diaryId) {
+        QRoute route = QRoute.route;
+        Integer max = query.select(route.orderIdx.max())
+                .from(route)
+                .where(route.diary.diaryId.eq(diaryId))
+                .fetchOne();
+        return max == null ? 1 : max + 1;
+    }
+
+    @Override
+    public List<RouteResponse> searchByDiary(Long diaryId) {
+        QRoute r = QRoute.route;
+        QAttraction a = QAttraction.attraction;
+
+        return query
+                .select(Projections.constructor(RouteResponse.class,
+                        r.id,
+                        r.orderIdx,
+                        r.visitedAt,
+                        a.no,
+                        a.title
+                ))
+                .from(r)
+                .join(r.attraction, a)
+                .where(r.diary.diaryId.eq(diaryId))
+                .orderBy(r.orderIdx.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/konnect/route/service/RouteService.java
+++ b/src/main/java/com/konnect/route/service/RouteService.java
@@ -4,8 +4,9 @@ import com.konnect.attraction.entity.Attraction;
 import com.konnect.attraction.repository.AttractionRepository;
 import com.konnect.diary.entity.DiaryEntity;
 import com.konnect.diary.repository.DiaryRepository;
+import com.konnect.route.dto.RouteCreateByDateRequest;
 import com.konnect.route.dto.RouteCreateRequest;
-import com.konnect.route.dto.RouteResponse;
+import com.konnect.route.dto.RouteDetailResponse;
 import com.konnect.route.dto.RouteUpdateRequest;
 import com.konnect.route.entity.Route;
 import com.konnect.route.repository.RouteRepository;
@@ -15,6 +16,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -28,13 +31,7 @@ public class RouteService {
 
     public Long create(RouteCreateRequest dto, Long userId) {
 
-        DiaryEntity diary = diaryRepository.findById(dto.diaryId())
-                .orElseThrow(() -> new EntityNotFoundException("Diary not found"));
-
-        // 다이어리 주인 검증
-        if (!diary.getUser().getUserId().equals(userId)) {
-            throw new AccessDeniedException("본인 다이어리가 아닙니다.");
-        }
+        DiaryEntity diary = validDiaryOfUser(dto.diaryId(), userId);
 
         Attraction attraction = attractionRepository.findById(dto.attractionNo())
                 .orElseThrow(() -> new EntityNotFoundException("Attraction not found"));
@@ -53,7 +50,7 @@ public class RouteService {
 
     /** READ (다이어리별) */
     @Transactional(readOnly = true)
-    public List<RouteResponse> listByDiary(Long diaryId) {
+    public List<RouteDetailResponse> listByDiary(Long diaryId) {
         return routeRepository.searchByDiary(diaryId);
     }
 
@@ -74,5 +71,45 @@ public class RouteService {
     /** DELETE */
     public void delete(Long id) {
         routeRepository.deleteById(id);
+    }
+
+
+    @Transactional
+    public Long createByDate(RouteCreateByDateRequest dto, Long userId) {
+        // (다이어리 주인 검증 로직 동일)
+        DiaryEntity diary = validDiaryOfUser(dto.diaryId(), userId);
+
+        Attraction attraction = attractionRepository.findById(dto.attractionNo())
+                .orElseThrow(() -> new EntityNotFoundException("Attraction not found"));
+
+        int order = dto.orderIdx() != null
+                ? dto.orderIdx()
+                : routeRepository.nextOrderIdx(diary.getDiaryId());
+
+        LocalDateTime visitedAt = dto.visitedDate().atTime(23, 59, 59);
+
+        Route route = Route.builder()
+                .diary(diary)
+                .attraction(attraction)
+                .orderIdx(order)
+                .visitedAt(visitedAt)
+                .build();
+
+        return routeRepository.save(route).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<RouteDetailResponse> listByDiaryAndDate(Long diaryId, LocalDate date) {
+        return routeRepository.searchByDiaryAndDate(diaryId, date);
+    }
+
+    /* 공통 유틸 */
+    private DiaryEntity validDiaryOfUser(Long diaryId, Long userId) {
+        DiaryEntity diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new EntityNotFoundException("Diary not found"));
+        if (!diary.getUser().getUserId().equals(userId)) {
+            throw new AccessDeniedException("본인 다이어리가 아닙니다.");
+        }
+        return diary;
     }
 }

--- a/src/main/java/com/konnect/route/service/RouteService.java
+++ b/src/main/java/com/konnect/route/service/RouteService.java
@@ -1,0 +1,78 @@
+package com.konnect.route.service;
+
+import com.konnect.attraction.entity.Attraction;
+import com.konnect.attraction.repository.AttractionRepository;
+import com.konnect.diary.entity.DiaryEntity;
+import com.konnect.diary.repository.DiaryRepository;
+import com.konnect.route.dto.RouteCreateRequest;
+import com.konnect.route.dto.RouteResponse;
+import com.konnect.route.dto.RouteUpdateRequest;
+import com.konnect.route.entity.Route;
+import com.konnect.route.repository.RouteRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RouteService {
+
+    private final RouteRepository routeRepository;
+    private final DiaryRepository diaryRepository;
+    private final AttractionRepository attractionRepository;
+
+    public Long create(RouteCreateRequest dto, Long userId) {
+
+        DiaryEntity diary = diaryRepository.findById(dto.diaryId())
+                .orElseThrow(() -> new EntityNotFoundException("Diary not found"));
+
+        // 다이어리 주인 검증
+        if (!diary.getUser().getUserId().equals(userId)) {
+            throw new AccessDeniedException("본인 다이어리가 아닙니다.");
+        }
+
+        Attraction attraction = attractionRepository.findById(dto.attractionNo())
+                .orElseThrow(() -> new EntityNotFoundException("Attraction not found"));
+
+        int order = dto.orderIdx() != null ? dto.orderIdx() : routeRepository.nextOrderIdx(diary.getDiaryId());
+
+        Route route = Route.builder()
+                .diary(diary)
+                .attraction(attraction)
+                .orderIdx(order)
+                .visitedAt(dto.visitedAt())
+                .build();
+
+        return routeRepository.save(route).getId();
+    }
+
+    /** READ (다이어리별) */
+    @Transactional(readOnly = true)
+    public List<RouteResponse> listByDiary(Long diaryId) {
+        return routeRepository.searchByDiary(diaryId);
+    }
+
+    /** UPDATE */
+    public void update(Long id, RouteUpdateRequest dto) {
+        Route route = routeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Route not found"));
+
+        if (dto.visitedAt() != null) route.updateVisitedAt(dto.visitedAt());
+        if (dto.orderIdx() != null)  route.updateOrder(dto.orderIdx());
+        if (dto.attractionNo() != null) {
+            Attraction attraction = attractionRepository.findById(dto.attractionNo())
+                    .orElseThrow(() -> new EntityNotFoundException("Attraction not found"));
+            route.changeAttraction(attraction);
+        }
+    }
+
+    /** DELETE */
+    public void delete(Long id) {
+        routeRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## 구현 api 목록
#### C
- 루트 생성
- 루트 생성(방문 TIMESTAMP 에서 방문날짜만 제공)
#### R
- 다이어리 id로 루트 목록 조회
- 다이어리 id, 방문 날짜로 루트 목록 조회
#### U
- 루트 수정(id 사용) -> 방문 날짜, 방문 순서, 관광지 번호 수정 가능
- 루트 순서 재정렬
#### D
- 루트 삭제(id 사용)